### PR TITLE
Add styled security notice view

### DIFF
--- a/equipment_booking_app/bookings/templates/bookings/security_notice.html
+++ b/equipment_booking_app/bookings/templates/bookings/security_notice.html
@@ -1,0 +1,11 @@
+{% extends 'bookings/base.html' %}
+
+{% block content %}
+<div class="container mt-5 text-center">
+    <h1 class="mb-4">Security Notice</h1>
+    <p>
+        This website is secured and undergoes regular security audits in accordance,
+        but not exclusively, with the OWASP Top 10.
+    </p>
+</div>
+{% endblock %}

--- a/equipment_booking_app/bookings/urls.py
+++ b/equipment_booking_app/bookings/urls.py
@@ -21,4 +21,5 @@ urlpatterns = [
     path('message/respond/<int:message_id>/', views.respond_to_message, name='respond_message'),
     path('manage-notice/', views.manage_notice, name='manage_notice'),
     path('remove_notice/', views.remove_notice, name='remove_notice'),
+    path('security-notice/', views.security_notice, name='security_notice'),
 ]

--- a/equipment_booking_app/bookings/views.py
+++ b/equipment_booking_app/bookings/views.py
@@ -315,3 +315,9 @@ def remove_notice(request):
         Notice.objects.all().delete()
         messages.success(request, 'Notice removed successfully.')
     return redirect('home')
+
+
+def security_notice(request):
+    """Inform visitors that the admin interface is secured."""
+    return render(request, 'bookings/security_notice.html')
+


### PR DESCRIPTION
## Summary
- style new security notice page using base layout
- route `/security-notice/` to the new view

## Testing
- `python manage.py check`
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68581c6878d48325a8f508d88a7993b0