### PR TITLE
Add dark mode toggle

### DIFF
--- a/equipment_booking_app/bookings/static/bookings/css/dark-mode.css
+++ b/equipment_booking_app/bookings/static/bookings/css/dark-mode.css
@@ -1,0 +1,27 @@
+body.full-dark-mode {
+    background-color: #000;
+    color: #fff;
+}
+body.full-dark-mode header,
+body.full-dark-mode footer {
+    background-color: #2c2c2c;
+    background-image: none;
+    color: #fff;
+    border-color: #444;
+}
+body.full-dark-mode main {
+    background-color: #121212;
+    color: #fff;
+}
+body.full-dark-mode .card {
+    background-color: #1e1e1e;
+    color: #fff;
+}
+body.full-dark-mode .form-control {
+    background-color: #333;
+    color: #fff;
+    border-color: #555;
+}
+body.full-dark-mode a {
+    color: #9ac;
+}

--- a/equipment_booking_app/bookings/templates/bookings/base.html
+++ b/equipment_booking_app/bookings/templates/bookings/base.html
@@ -8,6 +8,8 @@
     
     <!-- Bootstrap CSS CDN for responsive design and styling -->
     <link href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css" rel="stylesheet">
+    <!-- Font Awesome for theme toggle icons -->
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css" rel="stylesheet">
 
     <!-- Custom font definitions for the app -->
     <style>
@@ -109,6 +111,8 @@
 
     <!-- Link to the custom CSS file for additional styles -->
     <link rel="stylesheet" href="{% static 'bookings/css/styles.css' %}">
+    <!-- Dark mode styles -->
+    <link rel="stylesheet" href="{% static 'bookings/css/dark-mode.css' %}">
 </head>
 <body class="d-flex flex-column min-vh-100" style="background-color: #101e29; color: white;">
     <header>
@@ -160,8 +164,11 @@
     </main>
 
     <footer class="py-4 mt-auto">
-        <div class="container text-left">
-            <p style="font-size: 1.1rem;">&copy; 2025 AtkinsRéalis Equipment Booking App. For Support, please reach out to our friendly team through the contact page.</p>
+        <div class="container text-left d-flex justify-content-between align-items-center">
+            <p style="font-size: 1.1rem;" class="mb-0">&copy; 2025 AtkinsRéalis Equipment Booking App. For Support, please reach out to our friendly team through the contact page.</p>
+            <button id="theme-toggle" class="btn btn-link text-decoration-none" aria-label="Toggle dark mode">
+                <i class="fas fa-moon"></i>
+            </button>
         </div>
     </footer>
     
@@ -178,6 +185,21 @@
                 window.location.href = event.target.href;
             }
         }
+        document.addEventListener('DOMContentLoaded', function() {
+            const toggle = document.getElementById('theme-toggle');
+            const body = document.body;
+            const stored = localStorage.getItem('full-dark-mode');
+            if (stored === 'true') {
+                body.classList.add('full-dark-mode');
+                toggle.innerHTML = '<i class="fas fa-sun"></i>';
+            }
+            toggle.addEventListener('click', function() {
+                body.classList.toggle('full-dark-mode');
+                const enabled = body.classList.contains('full-dark-mode');
+                toggle.innerHTML = enabled ? '<i class="fas fa-sun"></i>' : '<i class="fas fa-moon"></i>';
+                localStorage.setItem('full-dark-mode', enabled);
+            });
+        });
     </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- include Font Awesome and new dark mode stylesheet
- add a footer button to toggle a full dark theme
- remember theme choice with local storage

## Testing
- `python3 manage.py check` *(fails: IndentationError in existing code)*

------
https://chatgpt.com/codex/tasks/task_e_68586507995c8325b4314b99261db65e