### PR TITLE
Add dark mode toggle

### DIFF
--- a/equipment_booking_app/bookings/static/bookings/css/styles.css
+++ b/equipment_booking_app/bookings/static/bookings/css/styles.css
@@ -42,6 +42,8 @@ h1, h2 {
 /* Main content grows with flex */
 main {
     flex: 1;
+    border-radius: 6px;
+    padding: 20px;
 }
 
 /* Logo */
@@ -115,3 +117,32 @@ main {
     background-color: #ffffff;
     color: #192d38;
 }
+
+/* Theme toggle */
+.theme-toggle-btn {
+    background: none;
+    border: none;
+    font-size: 1.5rem;
+    cursor: pointer;
+}
+
+body.light-mode {
+    background-color: #BEDAE5;
+    color: #192d38;
+}
+
+body.light-mode main {
+    background-color: #ffffff;
+    color: #192d38;
+}
+
+body.dark-mode {
+    background-color: #101e29;
+    color: white;
+}
+
+body.dark-mode main {
+    background-color: #192d38;
+    color: white;
+}
+

--- a/equipment_booking_app/bookings/static/bookings/js/theme-toggle.js
+++ b/equipment_booking_app/bookings/static/bookings/js/theme-toggle.js
@@ -1,0 +1,25 @@
+document.addEventListener('DOMContentLoaded', function () {
+    const toggle = document.getElementById('theme-toggle');
+    const body = document.body;
+
+    function setTheme(theme) {
+        if (theme === 'dark') {
+            body.classList.add('dark-mode');
+            body.classList.remove('light-mode');
+            toggle.textContent = '☀';
+        } else {
+            body.classList.add('light-mode');
+            body.classList.remove('dark-mode');
+            toggle.textContent = '🌙';
+        }
+        localStorage.setItem('theme', theme);
+    }
+
+    toggle.addEventListener('click', function () {
+        const newTheme = body.classList.contains('dark-mode') ? 'light' : 'dark';
+        setTheme(newTheme);
+    });
+
+    const saved = localStorage.getItem('theme') || 'light';
+    setTheme(saved);
+});

--- a/equipment_booking_app/bookings/templates/bookings/base.html
+++ b/equipment_booking_app/bookings/templates/bookings/base.html
@@ -112,7 +112,7 @@
     <!-- Link to the custom CSS file for additional styles -->
     <link rel="stylesheet" href="{% static 'bookings/css/styles.css' %}">
 </head>
-<body class="d-flex flex-column min-vh-100" style="background-color: #101e29; color: white;">
+<body class="d-flex flex-column min-vh-100">
     <header>
         <a href="{% url 'home' %}">
             <img src="{% static 'bookings/images/logo.png' %}" alt="Logo" class="logo">
@@ -156,14 +156,15 @@
     </div>
     {% endif %}
 
-    <main class="container flex-grow-1" style="background-color: #192d38; color: white; border-radius: 6px; padding: 20px;">
+    <main class="container flex-grow-1">
         {% block content %}
         {% endblock %}
     </main>
 
     <footer class="py-4 mt-auto">
-        <div class="container text-left">
-            <p style="font-size: 1.1rem;">&copy; 2025 AtkinsRéalis Equipment Booking App. For Support, please reach out to our friendly team through the contact page.</p>
+        <div class="container d-flex justify-content-between align-items-center">
+            <p style="font-size: 1.1rem;" class="mb-0">&copy; 2025 AtkinsRéalis Equipment Booking App. For Support, please reach out to our friendly team through the contact page.</p>
+            <button id="theme-toggle" class="theme-toggle-btn" aria-label="Toggle dark mode"></button>
         </div>
     </footer>
     
@@ -171,6 +172,7 @@
     <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2.5.2/dist/umd/popper.min.js"></script>
     <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/js/bootstrap.min.js"></script>
+    <script src="{% static 'bookings/js/theme-toggle.js' %}"></script>
 
     <script>
         function confirmLogout(event) {


### PR DESCRIPTION
## Summary
- add client-side theme toggle script and styles
- remove inline colour styles and add toggle button to footer
- style main container and add light/dark theme CSS

## Testing
- `python equipment_booking_app/manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_6858667081888325ba1634f5279ba79e