### PR TITLE
Switch card styling to dark mode

### DIFF
--- a/equipment_booking_app/bookings/static/bookings/css/styles.css
+++ b/equipment_booking_app/bookings/static/bookings/css/styles.css
@@ -111,11 +111,11 @@ main {
 
 /*
  * Ensure all Bootstrap cards across the site use a consistent
- * white background with dark text, matching the login form style.
+ * dark background with light text.
  */
 .card {
-    background-color: #ffffff;
-    color: #192d38;
+    background-color: #000000;
+    color: #ffffff;
 }
 
 /* Theme toggle */

--- a/equipment_booking_app/bookings/templates/bookings/account_detail.html
+++ b/equipment_booking_app/bookings/templates/bookings/account_detail.html
@@ -5,7 +5,7 @@
     <h2 class="text-center mb-4">Your Account Details</h2>
 
     <!-- Card for form layout with Bootstrap styling -->
-    <div class="card p-4 w-50 mx-auto mb-5" style="color: #192d38;">
+    <div class="card p-4 w-50 mx-auto mb-5" style="color: white;">
         <form method="post" action="{% url 'accounts' %}">
             {% csrf_token %}
 

--- a/equipment_booking_app/bookings/templates/bookings/contact.html
+++ b/equipment_booking_app/bookings/templates/bookings/contact.html
@@ -5,7 +5,7 @@
     <h2 class="text-center mb-4">Contact Us</h2>
 
     <!-- Card for styling the content, similar to booking form design -->
-    <div class="card p-4 w-75 mx-auto mb-5" style="color: #192d38;">
+    <div class="card p-4 w-75 mx-auto mb-5" style="color: white;">
         
         <!-- Check if the user is authenticated -->
         {% if user.is_authenticated %}

--- a/equipment_booking_app/bookings/templates/bookings/create_booking.html
+++ b/equipment_booking_app/bookings/templates/bookings/create_booking.html
@@ -5,7 +5,7 @@
     <h2 class="text-center mb-4">Create Booking</h2>
 
     <!-- Card box for form styling with white background and adjusted text color -->
-    <div class="card p-4 w-50 mx-auto mb-5" style="color: #192d38;">
+    <div class="card p-4 w-50 mx-auto mb-5" style="color: white;">
         <form method="post">
             {% csrf_token %}
 

--- a/equipment_booking_app/bookings/templates/bookings/edit_booking.html
+++ b/equipment_booking_app/bookings/templates/bookings/edit_booking.html
@@ -5,7 +5,7 @@
     <h2 class="text-center mb-4">Edit Booking</h2>
 
     <!-- Box around the form (Bootstrap card) with a white background and text color adjusted -->
-    <div class="card p-4 w-50 mx-auto mb-5" style="color: #192d38;">
+    <div class="card p-4 w-50 mx-auto mb-5" style="color: white;">
         <form method="post">
             {% csrf_token %}
 

--- a/equipment_booking_app/bookings/templates/bookings/home.html
+++ b/equipment_booking_app/bookings/templates/bookings/home.html
@@ -33,7 +33,7 @@
         <!-- Notice Board for Regular Users -->
         {% if notices %}
         <div class="card w-75 mb-2 mx-auto"> <!-- Changed from w-50 to w-75 and centered -->
-            <div class="card-body" style="color: #192d38;">
+            <div class="card-body" style="color: white;">
                 <h2 class="card-title">Notice Board</h2>
                 <p>{{ notices.message }}</p>
 
@@ -51,7 +51,7 @@
         <!-- Form for Superusers to Create Notices -->
         {% if user.is_superuser %}
         <div class="card w-75 mx-auto"> <!-- Also widened and centered -->
-            <div class="card-body" style="color: #192d38;">
+            <div class="card-body" style="color: white;">
                 <h2 class="card-title">Create a Notice</h2>
                 <form method="post">
                     {% csrf_token %}

--- a/equipment_booking_app/bookings/templates/bookings/login.html
+++ b/equipment_booking_app/bookings/templates/bookings/login.html
@@ -6,7 +6,7 @@
     <!-- Title shown above the login form -->
     <h1 class="text-center mb-4" style="color: white;">AtkinsRealis Booking App</h1>
     <!-- Bootstrap card for styling the login form -->
-    <div class="card p-4 w-50" style="color: #192d38;">  <!-- Text color applied here -->
+    <div class="card p-4 w-50" style="color: white;">  <!-- Text color applied here -->
         <h2 class="text-center mb-4">Login</h2>
 
         <!-- Login form with CSRF token for security -->
@@ -40,7 +40,7 @@
 
         <!-- Link to signup page for users without an account -->
         <div class="text-center mt-3">
-            <p>Don't have an account? <a href="{% url 'signup' %}" style="color: #192d38;">Sign up</a></p>
+            <p>Don't have an account? <a href="{% url 'signup' %}" style="color: white;">Sign up</a></p>
         </div>
     </div>
 </div>

--- a/equipment_booking_app/bookings/templates/bookings/signup.html
+++ b/equipment_booking_app/bookings/templates/bookings/signup.html
@@ -4,7 +4,7 @@
 <!-- Center the signup form both vertically and horizontally -->
 <div class="d-flex justify-content-center align-items-center" style="min-height: 80vh;">
     <!-- Bootstrap card for styling the signup form -->
-    <div class="card p-4 w-100" style="color: #192d38;">
+    <div class="card p-4 w-100" style="color: white;">
         <h1 class="text-center mb-4">Sign Up</h1>
         
         <!-- Signup form with CSRF token for security -->
@@ -20,7 +20,7 @@
 
         <!-- Link to login page for users who already have an account -->
         <div class="text-center mt-3">
-            <p>Already have an account? <a href="{% url 'login' %}" style="color: #192d38;">Login</a></p>
+            <p>Already have an account? <a href="{% url 'login' %}" style="color: white;">Login</a></p>
         </div>
     </div>
 </div>


### PR DESCRIPTION
## Summary
- use black backgrounds with white text for cards across the site
- update inline styles in templates to match

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6858681e82ac83259ae4a607a420ac71