### PR TITLE
Fix admin inbox table heading styling

### DIFF
--- a/equipment_booking_app/bookings/templates/bookings/inbox.html
+++ b/equipment_booking_app/bookings/templates/bookings/inbox.html
@@ -11,7 +11,7 @@
             {% csrf_token %}
             <div class="table-responsive">
                 <table class="table table-striped table-bordered table-hover w-150" style="background-color: #ffffff; width: 100%;">
-                    <thead style="background-color: #BE02F8; color: #192d38; font-size: 1.25rem;">
+                    <thead style="background-color: #BE02F8; color: #ffffff; font-size: 1.25rem; text-align: center;">
                         <tr class="text-center">
                             <th>Subject</th>
                             <th>Confirmation Number</th>
@@ -46,7 +46,7 @@
     {% if settled_messages %}
         <div class="table-responsive">
             <table class="table table-striped table-bordered table-hover w-100" style="background-color: #ffffff; width: 100%;">
-                <thead style="background-color: #BE02F8; color: #192d38; font-size: 1.25rem;">
+                <thead style="background-color: #BE02F8; color: #ffffff; font-size: 1.25rem; text-align: center;">
                     <tr class="text-center">
                         <th>Subject</th>
                         <th>Confirmation Number</th>


### PR DESCRIPTION
## Summary
- center the inbox table headers and use white text

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_6859326d49f08325919eb9a3da85806d