### PR TITLE
Fix overlapping booking feedback

### DIFF
--- a/equipment_booking_app/bookings/views.py
+++ b/equipment_booking_app/bookings/views.py
@@ -63,9 +63,23 @@ def create_booking(request):
         if form.is_valid():
             booking = form.save(commit=False)
             booking.user = form.cleaned_data['user'] if request.user.is_superuser else request.user
-            booking.save()
-            messages.success(request, 'Booking created successfully!')
-            return redirect('booking_list')
+
+            # Prevent overlapping bookings for the same equipment
+            overlap_exists = Booking.objects.filter(
+                equipment=booking.equipment,
+                start_time__lt=booking.end_time,
+                end_time__gt=booking.start_time
+            ).exists()
+
+            if overlap_exists:
+                messages.error(
+                    request,
+                    'This item is already reserved for the requested time. Please choose another time.'
+                )
+            else:
+                booking.save()
+                messages.success(request, 'Booking created successfully!')
+                return redirect('booking_list')
         else:
             messages.error(request, 'Error creating booking. Please ensure the equipment is available.')
     else:


### PR DESCRIPTION
## Summary
- avoid double-booking an item in `create_booking`
- show error message if equipment is already reserved

## Testing
- `python equipment_booking_app/manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_685943c6b8e08325b24277c7d3fccca6